### PR TITLE
Fix gcovr HTML templates for sidebar navigation and compatibility

### DIFF
--- a/scripts/build_tree.py
+++ b/scripts/build_tree.py
@@ -98,6 +98,52 @@ def get_coverage_class(coverage):
         return 'coverage-unknown'
 
 
+def clean_path(name):
+    """Remove relative path prefixes like '../../../' from a path.
+
+    Returns the cleaned path preserving directory structure.
+    E.g., '../../detail/impl/foo.hpp' -> 'detail/impl/foo.hpp'
+    """
+    name = name.rstrip('/')
+
+    # Remove leading ./ or ../
+    while name.startswith('./') or name.startswith('../'):
+        if name.startswith('./'):
+            name = name[2:]
+        elif name.startswith('../'):
+            name = name[3:]
+
+    return name if name else 'unknown'
+
+
+def clean_display_name(name):
+    """Extract clean display name from path.
+
+    Removes relative path prefixes like '../../../' and extracts
+    just the filename or last meaningful path segment.
+    """
+    # First clean the path
+    name = clean_path(name)
+
+    # If it still contains slashes, get the last segment
+    if '/' in name:
+        name = name.split('/')[-1]
+
+    # Fallback if empty
+    return name if name else 'unknown'
+
+
+def is_file_path(path):
+    """Check if a path looks like a file (has a file extension).
+
+    More reliable than gcovr's directory class detection for paths with '../'.
+    """
+    # Clean the path first
+    clean = clean_path(path)
+    # Check for common source file extensions
+    return bool(re.search(r'\.(hpp|ipp|cpp|h|c|cc|cxx|hxx|tpp|inl)$', clean, re.IGNORECASE))
+
+
 def build_tree(output_dir):
     """Build complete tree structure by following links recursively."""
     output_path = Path(output_dir)
@@ -110,7 +156,49 @@ def build_tree(output_dir):
         entries = parse_html_file(html_file)
         file_entries[html_file.name] = entries
 
-    def build_node_from_file(html_filename, visited=None):
+    def add_to_tree(nodes, path_parts, entry_data, base_path=''):
+        """Add an entry to the tree, creating intermediate directories as needed."""
+        if not path_parts:
+            return
+
+        name = path_parts[0]
+        remaining = path_parts[1:]
+        current_full_path = base_path + '/' + name if base_path else name
+
+        # Find existing node for this level
+        existing = None
+        for node in nodes:
+            if node.get('name') == name:
+                existing = node
+                break
+
+        if remaining:
+            # This is an intermediate directory - create if needed
+            if not existing:
+                existing = {
+                    'name': name,
+                    'fullPath': current_full_path,
+                    'coverage': '-',
+                    'coverageClass': 'coverage-unknown',
+                    'isDirectory': True,
+                    'link': None,
+                    'children': []
+                }
+                nodes.append(existing)
+            # Recurse into children
+            add_to_tree(existing['children'], remaining, entry_data, current_full_path)
+        else:
+            # This is the final entry (file or directory)
+            if existing:
+                # Update existing node with entry data (preserve children)
+                children = existing.get('children', [])
+                existing.update(entry_data)
+                if children and not existing.get('children'):
+                    existing['children'] = children
+            else:
+                nodes.append(entry_data)
+
+    def build_node_from_file(html_filename, current_path='', visited=None):
         """Recursively build tree from HTML file."""
         if visited is None:
             visited = set()
@@ -123,13 +211,29 @@ def build_tree(output_dir):
         nodes = []
 
         for entry in entries:
-            name = entry['name']
-            is_dir = entry['is_dir'] or '.' not in name
+            raw_name = entry['name']
+            cleaned_path = clean_path(raw_name)
+            display_name = clean_display_name(raw_name)
+            is_dir = not is_file_path(raw_name) and (entry['is_dir'] or '.' not in display_name)
             coverage = entry['coverage']
             link = entry['link']
 
-            node = {
-                'name': name,
+            # Calculate relative path from current directory
+            # cleaned_path might be "detail/charconv/impl/from_chars.ipp"
+            # current_path might be "detail/charconv"
+            # relative should be "impl/from_chars.ipp"
+            if current_path and cleaned_path.startswith(current_path + '/'):
+                relative_path = cleaned_path[len(current_path) + 1:]
+            elif current_path and cleaned_path == current_path:
+                relative_path = display_name
+            else:
+                relative_path = cleaned_path
+
+            path_parts = relative_path.split('/') if '/' in relative_path else [display_name]
+
+            node_data = {
+                'name': path_parts[-1] if path_parts else display_name,
+                'fullPath': cleaned_path,
                 'coverage': coverage,
                 'coverageClass': get_coverage_class(coverage),
                 'isDirectory': is_dir,
@@ -139,12 +243,23 @@ def build_tree(output_dir):
 
             # If directory with a link, recursively get its children
             if is_dir and link and link in file_entries:
-                node['children'] = build_node_from_file(link, visited.copy())
+                node_data['children'] = build_node_from_file(link, cleaned_path, visited.copy())
 
-            nodes.append(node)
+            # Add to tree, creating intermediate directories if needed
+            if len(path_parts) > 1:
+                # Create intermediate directories and add the file
+                add_to_tree(nodes, path_parts, node_data)
+            else:
+                nodes.append(node_data)
 
         # Sort: directories first, then files, alphabetically
-        nodes.sort(key=lambda x: (not x['isDirectory'], x['name'].lower()))
+        def sort_nodes(node_list):
+            node_list.sort(key=lambda x: (not x['isDirectory'], x['name'].lower()))
+            for n in node_list:
+                if n.get('children'):
+                    sort_nodes(n['children'])
+
+        sort_nodes(nodes)
         return nodes
 
     # Start from index.html
@@ -163,9 +278,12 @@ def inject_tree_data(output_dir, tree):
             with open(html_file, 'r', encoding='utf-8') as f:
                 content = f.read()
 
-            # Check if already injected (look for the actual data, not just the var name)
-            if 'window.GCOVR_TREE_DATA=[' in content or 'window.GCOVR_TREE_DATA={' in content:
-                continue
+            # Remove any existing GCOVR_TREE_DATA injection (from production files)
+            content = re.sub(
+                r'<script>window\.GCOVR_TREE_DATA=.*?;</script>\n?',
+                '',
+                content
+            )
 
             # Inject before </body>
             if '</body>' in content:

--- a/templates/html/directory_page.content.html
+++ b/templates/html/directory_page.content.html
@@ -34,20 +34,25 @@
          data-functions="{{row.functions.sort}}"
          data-branches="{{row.branches.sort}}">
 
+      {# Extract clean display name: just filename or last path segment #}
+      {% set clean_path = row.filename.rstrip('/') %}
+      {% set display_name = clean_path.split('/')[-1] if '/' in clean_path else clean_path %}
+      {% set display_name = display_name if display_name else row.filename %}
+      {% set is_file = '.' in display_name and not display_name.endswith('...') %}
       <div class="col-name">
         <span class="file-icon">
           {% if row.link is none %}
           <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M1.75 1A1.75 1.75 0 000 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0016 13.25v-8.5A1.75 1.75 0 0014.25 3H7.5a.25.25 0 01-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75z"></path></svg>
-          {% elif '.' in row.filename %}
+          {% elif is_file %}
           <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688a.252.252 0 00-.011-.013l-2.914-2.914a.272.272 0 00-.013-.011zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path></svg>
           {% else %}
           <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M1.75 1A1.75 1.75 0 000 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0016 13.25v-8.5A1.75 1.75 0 0014.25 3H7.5a.25.25 0 01-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75z"></path></svg>
           {% endif %}
         </span>
         {% if row.link is not none %}
-        <a href="{% if info.single_page %}#{% endif %}{{row.link}}" title="{{row.filename}}">{{row.filename}}</a>
+        <a href="{% if info.single_page %}#{% endif %}{{row.link}}" title="{{row.filename}}">{{display_name}}</a>
         {% else %}
-        <span class="no-link">{{row.filename}}</span>
+        <span class="no-link" title="{{row.filename}}">{{display_name}}</span>
         {% endif %}
       </div>
 

--- a/templates/html/gcovr.js
+++ b/templates/html/gcovr.js
@@ -27,6 +27,20 @@
     var segments = pathText.split(' / ');
     if (segments.length <= 1) return;
 
+    // Auto-detect and skip prefix segments not in tree (e.g., "boost", "json")
+    // Find the first segment that matches a root node in the tree
+    var startIndex = 0;
+    var rootNames = window.GCOVR_TREE_DATA.map(function(n) { return n.name; });
+    for (var i = 0; i < segments.length; i++) {
+      if (rootNames.indexOf(segments[i]) !== -1) {
+        startIndex = i;
+        break;
+      }
+    }
+    // Skip prefix segments
+    segments = segments.slice(startIndex);
+    if (segments.length === 0) return;
+
     // Create linked breadcrumb by traversing tree
     var fragment = document.createDocumentFragment();
     var currentNodes = window.GCOVR_TREE_DATA;
@@ -298,14 +312,20 @@
     header.appendChild(icon);
 
     // Label (with link if available)
+    // Use fullPath for tooltip if available, otherwise use name
+    var tooltipText = item.fullPath || item.name;
     var label = document.createElement('span');
     label.className = 'tree-label';
-    label.title = item.name;
+    // Apply coverage class for coloring
+    if (item.coverageClass) {
+      label.classList.add(item.coverageClass);
+    }
+    label.title = tooltipText;
     if (item.link) {
       var link = document.createElement('a');
       link.href = item.link;
       link.textContent = item.name;
-      link.title = item.name;
+      link.title = tooltipText;
       label.appendChild(link);
     } else {
       label.textContent = item.name;

--- a/templates/html/source_page.content.html
+++ b/templates/html/source_page.content.html
@@ -6,21 +6,11 @@
     <div class="source-title">{{filename}}</div>
     <div class="source-actions">
       <button type="button" class="btn btn-sm button_toggle_coveredLine show_coveredLine" value="coveredLine" title="Toggle covered lines">
-        <span class="btn-count">{{lines.exec - lines.partial}}</span> covered
+        <span class="btn-count">{{lines.covered|default(0)}}</span> covered
       </button>
       <button type="button" class="btn btn-sm button_toggle_uncoveredLine show_uncoveredLine" value="uncoveredLine" title="Toggle uncovered lines">
-        <span class="btn-count">{{lines.uncovered}}</span> uncovered
+        <span class="btn-count">{{lines.total|default(0) - lines.covered|default(0)}}</span> uncovered
       </button>
-      {% if lines.partial > 0 %}
-      <button type="button" class="btn btn-sm button_toggle_partialCoveredLine show_partialCoveredLine" value="partialCoveredLine" title="Toggle partial covered lines">
-        <span class="btn-count">{{lines.partial}}</span> partial
-      </button>
-      {% endif %}
-      {% if lines.excluded > 0 %}
-      <button type="button" class="btn btn-sm button_toggle_excludedLine show_excludedLine" value="excludedLine" title="Toggle excluded lines">
-        <span class="btn-count">{{lines.excluded}}</span> excluded
-      </button>
-      {% endif %}
     </div>
   </div>
 

--- a/templates/html/source_page.navigation.html
+++ b/templates/html/source_page.navigation.html
@@ -1,15 +1,7 @@
 {# -*- engine: jinja -*- #}
 <div class="nav-links">
-  <a class="nav-link nav-prev" href="{% if info.single_page %}#{% endif %}{{info.navigation[fname][0] or ROOT_FNAME}}" title="Previous file">
-    <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M9.78 12.78a.75.75 0 01-1.06 0L4.47 8.53a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 1.06L6.06 8l3.72 3.72a.75.75 0 010 1.06z"></path></svg>
-    Prev
-  </a>
-  <a class="nav-link nav-index" href="{% if info.single_page %}#{% else %}{{ROOT_FNAME}}{% endif %}" title="Back to index">
+  <a class="nav-link nav-index" href="{% if info.single_page %}#{% else %}index.html{% endif %}" title="Back to index">
     <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M6.906.664a1.749 1.749 0 012.187 0l5.25 4.2c.415.332.657.835.657 1.367v7.019A1.75 1.75 0 0113.25 15h-3.5a.75.75 0 01-.75-.75V9H7v5.25a.75.75 0 01-.75.75h-3.5A1.75 1.75 0 011 13.25V6.23c0-.531.242-1.034.657-1.366l5.25-4.2z"></path></svg>
-    Index
-  </a>
-  <a class="nav-link nav-next" href="{% if info.single_page %}#{% endif %}{{info.navigation[fname][1] or ROOT_FNAME}}" title="Next file">
-    Next
-    <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg>
+    Back to Index
   </a>
 </div>

--- a/templates/html/source_page.summary.html
+++ b/templates/html/source_page.summary.html
@@ -3,14 +3,14 @@
   <div class="source-info">
     <h2 class="source-filename">{{filename}}</h2>
     <div class="source-stats">
-      <span class="stat {{lines.class}}">
-        <strong>{{lines.coverage}}%</strong> Lines ({{lines.exec}}/{{lines.total}})
+      <span class="stat {{lines.class|default('')}}">
+        <strong>{{lines.covered_percent|default(lines.coverage)|default(0)}}%</strong> Lines ({{lines.covered|default(lines.exec)|default(0)}}/{{lines.total|default(0)}})
       </span>
-      <span class="stat {{functions.class}}">
-        <strong>{{functions.coverage}}%</strong> Functions ({{functions.exec}}/{{functions.total}})
+      <span class="stat {{functions.class|default('')}}">
+        <strong>{{functions.covered_percent|default(functions.coverage)|default(0)}}%</strong> Functions ({{functions.covered|default(functions.exec)|default(0)}}/{{functions.total|default(0)}})
       </span>
-      <span class="stat {{branches.class}}">
-        <strong>{{branches.coverage}}%</strong> Branches ({{branches.exec}}/{{branches.total}})
+      <span class="stat {{branches.class|default('')}}">
+        <strong>{{branches.covered_percent|default(branches.coverage)|default(0)}}%</strong> Branches ({{branches.covered|default(branches.exec)|default(0)}}/{{branches.total|default(0)}})
       </span>
     </div>
   </div>


### PR DESCRIPTION
#### Summary
Fixes several issues with the custom gcovr HTML templates that caused rendering errors and improved sidebar tree navigation.

#### Changes

**Template fixes**
- Removed Prev/Next file navigation that depended on `info.navigation` (not available in all gcovr versions).
- Removed references to `lines.partial` and `lines.excluded` which don't exist in current gcovr output.
- Added fallback defaults for coverage variables to support different gcovr versions (`lines.exec` vs `lines.covered`).

**Sidebar tree improvements**
- Fixed display of paths with `../` prefixes – now shows clean filenames instead of `../../../detail/file.hpp`.
- Improved file vs folder icon detection for entries with relative paths.
- Tree now creates intermediate directories when gcovr doesn't provide separate pages for them.
- Applied coverage-based coloring to tree labels (gray for auto-created folders without coverage data).

**Breadcrumb fixes**
- JavaScript auto-detects and strips path prefixes (e.g., `boost/json/`) that don't exist in the sidebar tree.
- Breadcrumbs now stay in sync with sidebar tree structure.

#### Testing
Tested with production coverage data from Boost.JSON library.