### PR TITLE
Fix badge generation for functions and branches coverage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,11 +57,13 @@ else
         --exclude '.*/extra/.*' \
         --filter "$GCOVRFILTER" \
         --html \
-        --output "$outputlocation/index.html"
+        --output "$outputlocation/index.html" \
+        --json-summary-pretty \
+        --json-summary "$outputlocation/summary.json"
 
     # Generate tree.json for sidebar navigation
     python3 "../scripts/build_tree.py" "$outputlocation"
 
     # Generate coverage badges
-    python3 "../scripts/generate_badges.py" "$outputlocation"
+    python3 "../scripts/generate_badges.py" "$outputlocation" --json "$outputlocation/summary.json"
 fi


### PR DESCRIPTION
## Summary

- Add `--json-summary` output to the gcovr command in `build.sh` so badge generation can use structured data instead of HTML scraping
- Update JSON summary parser in `generate_badges.py` to read coverage keys (`line_percent`, `function_percent`, `branch_percent`) from the top-level JSON object, matching gcovr's actual summary format

## Context

Badges were only generated for line coverage. Function and branch badges were skipped with "no data available" because the badge generator relied on parsing HTML summary cards, which don't always contain function/branch percentages (e.g. when using the lcov conversion pipeline).

By adding `--json-summary` to the gcovr invocation, we get a structured JSON file with all three coverage metrics directly from gcovr. The badge generator now reads this JSON, which reliably includes line, function, and branch percentages.

## Test plan

- [x] Ran Docker build end-to-end (on ci-automation) with `lcov-jenkins-gcc-13.sh --only-gcovr`
- [x] Verified `summary.json` contains `line_percent: 93.3`, `function_percent: 56.3`, `branch_percent: 73.8`
- [x] Verified all 3 badges generated: `coverage-lines.svg`, `coverage-functions.svg`, `coverage-branches.svg`

ref #4 
