### PR TITLE
Add flat/nested view toggle, relocate source nav, and fix FOUT

### DIFF
--- a/templates/html/base.html
+++ b/templates/html/base.html
@@ -16,14 +16,28 @@
           : window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
         document.documentElement.setAttribute('data-theme', theme);
 
+        // Apply flat mode immediately to prevent sidebar flash
+        if (localStorage.getItem('gcovr-view-mode') === 'flat') {
+          document.documentElement.classList.add('early-flat-mode');
+        }
       })();
     </script>
+    {% if css_link is defined %}
+    <link rel="stylesheet" href="{{css_link}}"/>
+    {% else %}
     <style type="text/css">
-{% include "style.css" %}
+{{ css | safe }}
     </style>
+    {% endif %}
+    {% if not info.static_report %}
+    {% if javascript_link is defined %}
+    <script src="{{javascript_link}}"></script>
+    {% else %}
     <script>
-{% include "gcovr.js" %}
+{{ javascript | safe }}
     </script>
+    {% endif %}
+    {% endif %}
   </head>
 
   <body>
@@ -80,6 +94,10 @@
           </div>
           <div class="header-actions">
             {% block navigation %}{% endblock %}
+          </div>
+          <div class="view-toggle" id="view-toggle" style="display:none">
+            <button class="view-btn active" data-view="nested">Nested</button>
+            <button class="view-btn" data-view="flat">Flat</button>
           </div>
           <button class="theme-toggle" id="theme-toggle" title="Toggle theme">
             <svg class="icon-moon" viewBox="0 0 16 16" fill="currentColor"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>

--- a/templates/html/directory_page.content.html
+++ b/templates/html/directory_page.content.html
@@ -36,8 +36,15 @@
          data-filename="{{row.filename}}"
          data-coverage="{{row.lines.sort}}"
          data-lines="{{row.lines.total}}"
+         data-lines-exec="{{row.lines.exec}}"
+         data-lines-coverage="{{row.lines.coverage}}"
+         data-lines-class="{{row.lines.class}}"
          data-functions="{{row.functions.sort}}"
-         data-branches="{{row.branches.sort}}">
+         data-functions-coverage="{{row.functions.coverage}}"
+         data-functions-class="{{row.functions.class}}"
+         data-branches="{{row.branches.sort}}"
+         data-branches-coverage="{{row.branches.coverage}}"
+         data-branches-class="{{row.branches.class}}">
       <div class="col-name">
         <span class="file-icon">
           {% if row.link is none %}

--- a/templates/html/source_page.content.html
+++ b/templates/html/source_page.content.html
@@ -6,7 +6,7 @@
 <div class="source-container{% if not has_branches %} no-branches{% endif %}">
   <div class="source-header">
     <div class="source-title">{{filename}}</div>
-    <div class="source-actions">
+    <div class="source-line-filters">
       <button type="button" class="btn btn-sm button_toggle_coveredLine show_coveredLine" value="coveredLine" title="Toggle covered lines">
         <span class="btn-count">{{lines.exec - partial_count}}</span> covered
       </button>
@@ -24,6 +24,22 @@
       </button>
       {% endif %}
     </div>
+    {% if info.navigation is defined and fname in info.navigation %}
+    <div class="source-nav-links">
+      <a class="nav-link nav-prev" href="{% if info.single_page %}#{% endif %}{{info.navigation[fname][0] or ROOT_FNAME}}" title="Previous file">
+        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M9.78 12.78a.75.75 0 01-1.06 0L4.47 8.53a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 1.06L6.06 8l3.72 3.72a.75.75 0 010 1.06z"></path></svg>
+        Prev
+      </a>
+      <a class="nav-link nav-index" href="{% if info.single_page %}#{% else %}{{ROOT_FNAME}}{% endif %}" title="Back to index">
+        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M6.906.664a1.749 1.749 0 012.187 0l5.25 4.2c.415.332.657.835.657 1.367v7.019A1.75 1.75 0 0113.25 15h-3.5a.75.75 0 01-.75-.75V9H7v5.25a.75.75 0 01-.75.75h-3.5A1.75 1.75 0 011 13.25V6.23c0-.531.242-1.034.657-1.366l5.25-4.2z"></path></svg>
+        Index
+      </a>
+      <a class="nav-link nav-next" href="{% if info.single_page %}#{% endif %}{{info.navigation[fname][1] or ROOT_FNAME}}" title="Next file">
+        Next
+        <svg viewBox="0 0 16 16" width="16" height="16"><path fill="currentColor" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg>
+      </a>
+    </div>
+    {% endif %}
   </div>
 
   <div class="source-table-container">

--- a/templates/html/source_page.html
+++ b/templates/html/source_page.html
@@ -33,10 +33,6 @@
 {% include "source_page.summary.html" %}
 {% endblock %}
 
-{% block navigation %}
-{% include "source_page.navigation.html" %}
-{% endblock %}
-
 {% block content %}
 {% include "source_page.content.html" %}
 {% endblock %}

--- a/templates/html/source_page.summary.html
+++ b/templates/html/source_page.summary.html
@@ -14,13 +14,4 @@
       </span>
     </div>
   </div>
-
-  <div class="source-controls">
-    <button class="btn btn-toggle show_coveredLine" data-line-class="coveredLine" id="toggle-covered" title="Toggle covered lines">
-      <span class="color-dot covered"></span> Covered
-    </button>
-    <button class="btn btn-toggle show_uncoveredLine" data-line-class="uncoveredLine" id="toggle-uncovered" title="Toggle uncovered lines">
-      <span class="color-dot uncovered"></span> Uncovered
-    </button>
-  </div>
 </div>

--- a/templates/html/style.css
+++ b/templates/html/style.css
@@ -522,8 +522,8 @@ body.sidebar-resizing .main-content {
 
 /* Theme Toggle (in header) */
 .theme-toggle {
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border-color);
   background: var(--bg-tertiary);
@@ -1339,7 +1339,6 @@ body.sidebar-resizing .main-content {
 
 .source-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
   background: var(--bg-tertiary);
@@ -1355,10 +1354,16 @@ body.sidebar-resizing .main-content {
   color: var(--text-primary);
 }
 
-.source-actions {
+.source-line-filters {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.source-nav-links {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
 }
 
 .source-table-container {
@@ -1861,7 +1866,7 @@ body.sidebar-resizing .main-content {
    =========================================== */
 
 ::-webkit-scrollbar {
-  width: 12px;
+  width: 8px;
   height: 8px;
 }
 
@@ -1893,4 +1898,96 @@ body.sidebar-resizing .main-content {
 .button_toggle_excludedLine.show_excludedLine {
   text-decoration: none;
   opacity: 1;
+}
+
+/* Source line filter color tints */
+.source-line-filters .button_toggle_coveredLine {
+  border: 1px solid rgba(63, 185, 80, 0.4);
+  border-left: 3px solid rgba(63, 185, 80, 0.5);
+  background: var(--coverage-high-bg);
+}
+
+.source-line-filters .button_toggle_uncoveredLine {
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  border-left: 3px solid rgba(248, 81, 73, 0.5);
+  background: var(--coverage-low-bg);
+}
+
+.source-line-filters .button_toggle_partialCoveredLine {
+  border: 1px solid rgba(210, 153, 34, 0.4);
+  border-left: 3px solid rgba(210, 153, 34, 0.5);
+  background: var(--coverage-medium-bg);
+}
+
+.source-line-filters .button_toggle_excludedLine {
+  border: 1px solid var(--border-color);
+  border-left: 3px solid var(--border-color);
+  background: var(--bg-hover);
+}
+
+/* ===========================================
+   Header Separator
+   =========================================== */
+
+.header-separator {
+  width: 1px;
+  height: 24px;
+  background: var(--border-color);
+  flex-shrink: 0;
+  margin: 0 4px;
+}
+
+/* ===========================================
+   View Toggle (Nested / Flat)
+   =========================================== */
+
+.view-toggle {
+  display: inline-flex;
+  height: 30px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.view-btn {
+  padding: 0 14px;
+  height: 100%;
+  background: var(--bg-tertiary);
+  border: none;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.view-btn:first-child {
+  border-right: 1px solid var(--border-color);
+}
+
+.view-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.view-btn.active {
+  background: var(--accent-blue);
+  color: #ffffff;
+}
+
+/* Flat mode: hide sidebar, full-width main content */
+.app-container.flat-mode .sidebar,
+.early-flat-mode .sidebar {
+  display: none;
+}
+
+.app-container.flat-mode .sidebar-backdrop,
+.early-flat-mode .sidebar-backdrop {
+  display: none;
+}
+
+.app-container.flat-mode .main-content,
+.early-flat-mode .main-content {
+  margin-left: 12px !important;
 }


### PR DESCRIPTION
- Flat/nested view toggle with localStorage persistence
- File navigation moved into source header bar
- Color-tinted line filter buttons (covered/uncovered/partial)
- Coverage data attributes added to file rows and tree JSON
- FOUT fix via interaction-gated no-transitions
- External CSS/JS support via css_link/javascript_link

fixes #17 