### PR TITLE
Fix flat view missing coverage data

### DIFF
--- a/scripts/build_tree.py
+++ b/scripts/build_tree.py
@@ -40,7 +40,15 @@ class FileListParser(HTMLParser):
                     'name': attrs_dict.get('data-filename', ''),
                     'coverage': attrs_dict.get('data-coverage', '0'),
                     'is_dir': 'directory' in classes,
-                    'link': None
+                    'link': None,
+                    'linesTotal': attrs_dict.get('data-lines', ''),
+                    'linesExec': attrs_dict.get('data-lines-exec', ''),
+                    'linesCoverage': attrs_dict.get('data-lines-coverage', ''),
+                    'linesClass': attrs_dict.get('data-lines-class', ''),
+                    'functionsCoverage': attrs_dict.get('data-functions-coverage', ''),
+                    'functionsClass': attrs_dict.get('data-functions-class', ''),
+                    'branchesCoverage': attrs_dict.get('data-branches-coverage', ''),
+                    'branchesClass': attrs_dict.get('data-branches-class', ''),
                 }
 
         # Capture links in file rows
@@ -144,6 +152,14 @@ def build_tree(output_dir):
                 'name': name,
                 'coverage': coverage,
                 'coverageClass': get_coverage_class(coverage),
+                'linesTotal': entry.get('linesTotal', ''),
+                'linesExec': entry.get('linesExec', ''),
+                'linesCoverage': entry.get('linesCoverage', ''),
+                'linesClass': entry.get('linesClass', ''),
+                'functionsCoverage': entry.get('functionsCoverage', ''),
+                'functionsClass': entry.get('functionsClass', ''),
+                'branchesCoverage': entry.get('branchesCoverage', ''),
+                'branchesClass': entry.get('branchesClass', ''),
                 'isDirectory': is_dir,
                 'link': link,
                 'children': []


### PR DESCRIPTION
### Summary
- `build_tree.py` only extracted coverage and coverageClass from HTML file rows, but the flat view in `gcovr.js` needs linesCoverage, linesExec, linesTotal, functionsClass, etc. to render rows                                                                                                     
- Now extracts all 8 coverage data-* attributes so flat view displays correctly
- Nested view was unaffected

fixes #21 