### PR TITLE
Condense source header buttons for a more compact layout

### DIFF
--- a/templates/html/gcovr.js
+++ b/templates/html/gcovr.js
@@ -17,6 +17,7 @@
     initTreeControls();
     initViewToggle();
     initTlaNavigation();
+    initColumnToggles();
     initPopupResize();
 
     // Reveal page now that all init is done
@@ -1385,6 +1386,58 @@
       });
       cell.appendChild(a);
     }
+  }
+
+  // ===========================================
+  // Column Visibility Toggles
+  // ===========================================
+
+  function initColumnToggles() {
+    var buttons = document.querySelectorAll('.col-toggle');
+    if (buttons.length === 0) return;
+
+    var table = document.querySelector('.source-table');
+    if (!table) return;
+
+    // Restore saved state
+    var hidden = [];
+    try {
+      var saved = localStorage.getItem('gcovr-hidden-columns');
+      if (saved) hidden = JSON.parse(saved);
+    } catch (e) {}
+
+    // Apply saved hidden columns
+    for (var i = 0; i < hidden.length; i++) {
+      table.classList.add('hide-col-' + hidden[i]);
+    }
+
+    // Update button appearance to match state
+    buttons.forEach(function(btn) {
+      var col = btn.getAttribute('data-col');
+      if (hidden.indexOf(col) >= 0) {
+        btn.classList.remove('show-col');
+      }
+    });
+
+    // Handle clicks
+    buttons.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var col = this.getAttribute('data-col');
+        var hideClass = 'hide-col-' + col;
+        var isHidden = table.classList.toggle(hideClass);
+        this.classList.toggle('show-col', !isHidden);
+
+        // Save state
+        var current = [];
+        var allBtns = document.querySelectorAll('.col-toggle');
+        allBtns.forEach(function(b) {
+          if (!b.classList.contains('show-col')) {
+            current.push(b.getAttribute('data-col'));
+          }
+        });
+        localStorage.setItem('gcovr-hidden-columns', JSON.stringify(current));
+      });
+    });
   }
 
   // ===========================================

--- a/templates/html/source_page.content.html
+++ b/templates/html/source_page.content.html
@@ -24,6 +24,13 @@
       </button>
       {% endif %}
     </div>
+    <div class="source-column-filters">
+      {% if has_branches %}
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="branch" title="Toggle Branch column">Branch</button>
+      {% endif %}
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="tla" title="Toggle TLA column">TLA</button>
+      <button type="button" class="btn btn-sm col-toggle show-col" data-col="count" title="Toggle Hits column">Hits</button>
+    </div>
     {% if info.navigation is defined and fname in info.navigation %}
     <div class="source-nav-links">
       <a class="nav-link nav-prev" href="{% if info.single_page %}#{% endif %}{{info.navigation[fname][0] or ROOT_FNAME}}" title="Previous file">

--- a/templates/html/style.css
+++ b/templates/html/style.css
@@ -1345,11 +1345,11 @@ body.sidebar-resizing .main-content {
 .source-header {
   display: flex;
   align-items: center;
-  padding: 12px 16px;
+  padding: 8px 12px;
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-color);
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
 }
 
 .source-title {
@@ -1361,14 +1361,41 @@ body.sidebar-resizing .main-content {
 
 .source-line-filters {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
+}
+
+.source-column-filters {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.col-toggle {
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+
+.col-toggle.show-col {
+  text-decoration: none;
+  opacity: 1;
 }
 
 .source-nav-links {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   margin-left: auto;
+}
+
+.source-header .btn.btn-sm {
+  padding: 2px 6px;
+  gap: 4px;
+}
+
+.source-header .nav-link {
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  gap: 2px;
 }
 
 .source-table-container {
@@ -1546,6 +1573,11 @@ body.sidebar-resizing .main-content {
   background: var(--coverage-medium-bg);
   color: var(--coverage-medium);
 }
+
+/* Column visibility toggle hide rules */
+.source-table.hide-col-branch .col-branch { display: none; }
+.source-table.hide-col-tla .col-tla { display: none; }
+.source-table.hide-col-count .col-count { display: none; }
 
 .hit-miss {
   color: var(--coverage-low);


### PR DESCRIPTION
Reduce padding, gaps, and font sizes for buttons and nav links scoped to .source-header so other UI buttons are unaffected.

- Tighten .source-header container padding and gap
- Add .source-header .btn.btn-sm override with smaller padding/gap
- Add .source-header .nav-link override with smaller padding/font
- Reduce inner group gaps for line filters, column filters, nav links
- Add .source-column-filters, .col-toggle, and column visibility rules