### PR TITLE
Fix XSS vulnerability in flat/nested view toggle

### DIFF
--- a/templates/html/gcovr.js
+++ b/templates/html/gcovr.js
@@ -1073,7 +1073,7 @@
       return;
     }
 
-    var originalContent = null; // stash for restoring nested view
+    var originalNodes = null; // stash for restoring nested view
 
     function collectFlatFiles(nodes, parentPath) {
       var results = [];
@@ -1205,9 +1205,12 @@
     function switchToFlat() {
       if (!window.GCOVR_TREE_DATA) return;
 
-      // Stash original content
-      if (originalContent === null) {
-        originalContent = fileList.innerHTML;
+      // Stash original DOM nodes
+      if (originalNodes === null) {
+        originalNodes = document.createDocumentFragment();
+        while (fileList.firstChild) {
+          originalNodes.appendChild(fileList.firstChild);
+        }
       }
 
       var flatFiles = collectFlatFiles(window.GCOVR_TREE_DATA, '');
@@ -1219,7 +1222,9 @@
         return aVal - bVal;
       });
 
-      fileList.innerHTML = '';
+      while (fileList.firstChild) {
+        fileList.removeChild(fileList.firstChild);
+      }
       for (var i = 0; i < flatFiles.length; i++) {
         fileList.appendChild(buildFlatRow(flatFiles[i]));
       }
@@ -1230,8 +1235,12 @@
     }
 
     function switchToNested() {
-      if (originalContent !== null) {
-        fileList.innerHTML = originalContent;
+      if (originalNodes !== null) {
+        while (fileList.firstChild) {
+          fileList.removeChild(fileList.firstChild);
+        }
+        fileList.appendChild(originalNodes);
+        originalNodes = null;
       }
       if (appContainer) appContainer.classList.remove('flat-mode');
       document.documentElement.classList.remove('early-flat-mode');


### PR DESCRIPTION
Codacy flagged a potential XSS issue on line 1234 of gcovr.js. The flat/nested view switcher was saving the nested view as a raw HTML string via `fileList.innerHTML` and restoring it later by writing that string back. Static analyzers treat this as a tainted data sink since the value could theoretically be manipulated between save and restore.

Fixed by using a `DocumentFragment` to detach and reattach the actual DOM nodes instead. This avoids the HTML string round-trip entirely. No serialization, no parsing, no XSS surface.

Tested locally by generating a full report and toggling between flat/nested views, including sorting after switching back.

fixes #26 