### PR TITLE
Fix infinite loop in updateNavLinks

### DIFF
--- a/templates/html/gcovr.js
+++ b/templates/html/gcovr.js
@@ -1577,7 +1577,7 @@
             a.className = el.className.replace(/\bdisabled\b/, '').trim();
             a.href = href;
             a.title = el.title;
-            while (el.firstChild) a.appendChild(el.firstChild.cloneNode(true));
+            while (el.firstChild) a.appendChild(el.firstChild);
             el.parentNode.replaceChild(a, el);
           }
         } else {
@@ -1586,7 +1586,7 @@
             var span = document.createElement('span');
             span.className = el.className + ' disabled';
             span.title = el.title;
-            while (el.firstChild) span.appendChild(el.firstChild.cloneNode(true));
+            while (el.firstChild) span.appendChild(el.firstChild);
             el.parentNode.replaceChild(span, el);
           } else {
             el.classList.add('disabled');


### PR DESCRIPTION
## Summary
- `cloneNode(true)` copies child nodes without removing them from the source element, causing `while(el.firstChild)` to loop forever
- Replaced with `appendChild(el.firstChild)` which moves nodes out of the source, terminating the loop
- Only triggered on the first/last source file where prev/next nav links swap between `<a>` and `<span>`

Fixes #37