### PR TITLE
Add scrollable file list on directory pages

### DIFF
--- a/templates/html/style.css
+++ b/templates/html/style.css
@@ -957,6 +957,7 @@ body.sidebar-resizing .main-content {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 
 .main-footer {
@@ -1115,6 +1116,16 @@ body.sidebar-resizing .main-content {
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.file-list-body {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 200px;
 }
 
 .file-list-header {


### PR DESCRIPTION
Allow main section to scroll on short viewports so summary cards and file list remain accessible. File list body scrolls independently with a 200px minimum height.

resolves #35 