### PR TITLE
Adjust build_tree to show directories that were otherwise missing

### DIFF
--- a/scripts/build_tree.py
+++ b/scripts/build_tree.py
@@ -107,15 +107,23 @@ def get_coverage_class(coverage):
 
 
 def clean_name(raw_name):
-    """Extract the leaf name from a possibly relative path."""
+    """Keep a stable relative path for tree normalization."""
     if not raw_name:
         return raw_name
     cleaned = raw_name
     while cleaned.startswith('../') or cleaned.startswith('./'):
         cleaned = cleaned[3:] if cleaned.startswith('../') else cleaned[2:]
-    if '/' in cleaned:
-        cleaned = cleaned.rsplit('/', 1)[-1]
     return cleaned or raw_name
+
+
+def normalize_link(href):
+    """Normalize a link so it can match parsed HTML filenames."""
+    if not href:
+        return href
+    link = href.strip()
+    while link.startswith('./'):
+        link = link[2:]
+    return link
 
 
 def build_tree(output_dir):
@@ -146,7 +154,7 @@ def build_tree(output_dir):
             name = clean_name(entry['name'])
             is_dir = entry['is_dir'] or '.' not in name
             coverage = entry['coverage']
-            link = entry['link']
+            link = normalize_link(entry['link'])
 
             node = {
                 'name': name,


### PR DESCRIPTION
This modification is not 100% certain.
It was coded by Claude, and allowed an upstream gcovr/gcovr problem to surface.  
Without the change, a file subdir1/subdir2/subdir3/file.cpp was completely failing to appear.   Therefore it seems like a step in the right direction.    However, btw, subdir1 is ordered in a funny way, not at the top with the other directories, sorted as a file.  

@julioest 

